### PR TITLE
Fixed long description README path.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
         maintainer=find_meta("author"),
         maintainer_email=find_meta("email"),
         keywords=KEYWORDS,
-        long_description=read("README.rst"),
+        long_description=read("README.md"),
         packages=PACKAGES,
         package_dir={"": "src"},
         zip_safe=False,


### PR DESCRIPTION
I got this error installing from source:

```
    FileNotFoundError: [Errno 2] No such file or directory: '/projects/christmas_2019/grbl-stream/README.rst'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```